### PR TITLE
【HE-paper】High-Precision Bootstrapping for Approximate Homomorphic Encryption by Error Variance Minimization

### DIFF
--- a/cryptography/he.md
+++ b/cryptography/he.md
@@ -172,6 +172,10 @@ Communications of the ACM, [paper](https://dl.acm.org/doi/pdf/10.1145/359340.359
   *Ilaria Chillotti, Damien Ligier, Jean-Baptiste Orfila, Samuel Tap*
   ASIACRYPT 2021, [paper](https://eprint.iacr.org/2021/729.pdf), CLO+21
 
+- High-Precision Bootstrapping for Approximate Homomorphic Encryption by Error Variance Minimization
+  *Yongwoo Lee, Joon-Woo Lee, Young-Sik Kim, Yongjune Kim, Jong-Seon No, and HyungChul Kang*
+  EUROCRYPT 2022, [paper](https://eprint.iacr.org/2020/1549.pdf), LLK+22
+
 - Efficient FHEW Bootstrapping with Small Evaluation Keys, and Applications to Threshold Homomorphic Encryption
   *Yongwoo Lee, Daniele Micciancio, Andrey Kim, Rakyong Choi, Maxim Deryabin, Jieun Eom, Donghoon Yoo*
   EUROCRYPT 2023, [paper](https://eprint.iacr.org/2022/198.pdf), LMK+23


### PR DESCRIPTION
- 推荐类别：顶会论文
- 标题：High-Precision Bootstrapping for Approximate Homomorphic Encryption by Error Variance Minimization
- 收录会议：EUROCRYPT 2022（三大密）
- 论文链接：https://eprint.iacr.org/2020/1549.pdf
- 推荐理由：

该论文发表于密码学顶级会议Eurocrypt 2022，提出了一种针对近似同态加密方案CKKS的高精度自举（Bootstrapping）算法，其核心创新在于通过误差方差最小化实现了模归约（Modular Reduction）的直接最优多项式近似以及提出一种高效的Lazy BSGS评估算法。 

Cheon-Kim-Kim-Song (CKKS) 方案 (Asiacrypt'17) 因支持对实数/复数的高效加密计算而成为最有前途的同态加密 (HE) 方案之一，但其自举操作一直是性能瓶颈，而模归约的同态求值又是自举的核心挑战。由于模归约无法直接用复数加法/乘法表达，传统方法需依赖其近似多项式。Eurocrypt'21技术 (High-Precision Bootstrapping of RNS-CKKS Homomorphic Encryption Using Optimal Minimax Polynomial Approximation and Inverse Sine Function) 使用三角函数的组合进行间接近似，但需要极高的乘法深度才能达到高精度。该论文提出了一种直接的多项式近似方法，在误差方差和所需乘法深度上均达到最优，并结合新颖的“lazy-BSGS”算法（利用懒惰重线性化/缩放过载技术），将近似多项式同态求值的计算复杂度直接减半，相关技术细节可参考论文原文。

该论文发表后，一部分研究者遵循其直接近似与最优误差方差的思路，尝试应用到更复杂的同态计算原语中。 例如，BLEACH: Cleaning Errors in Discrete Computations Over CKKS（Journal of Cryptology 2024）提出了两种针对一般阶跃函数的多项式近似方法以有效解决阶跃函数的同态计算问题；另一部分研究者则尝试将该范式中的技术迁移到其他同态加密方案的优化中。 例如，Simpler and Faster BFV Bootstrapping for Arbitrary Plaintext Modulus from CKKS (CCS 2024) 将该算法应用于增强BFV自举。 

综上所述，该论文在CKKS自举领域实现了较大进展，显著降低了高精度自举所需的计算开销（深度），为隐私保护机器学习、安全联邦学习等依赖高精度浮点同态计算的应用奠定了道路。 对于想深入理解高精度CKKS自举前沿技术、探索同态加密计算深度优化的研究者们，推荐精读该论文。
