### PR TITLE
【PSI-paper】Practical Multi-party Private Set Intersection from Symmetric-Key Techniques

### DIFF
--- a/cryptography/psi.md
+++ b/cryptography/psi.md
@@ -138,3 +138,7 @@ Note: one paper may be included in several categories (e.g. a paper may introduc
 - Malicious Secure, Structure-Aware Private Set Intersection
   *Gayathri Garimella, Mike Rosulek, Jaspal Singh*
   CRYPTO 2023, [eprint](https://eprint.iacr.org/2023/1166), GRS23
+
+- Practical Multi-party Private Set Intersection from Symmetric-Key Techniques
+  *Vladimir Kolesnikov, Naor Matania, Benny Pinkas, Mike Rosulek, Ni Trieu*
+  CCS 2017, [eprint](https://eprint.iacr.org/2017/799.pdf), KMPR+17


### PR DESCRIPTION
- 推荐类别：顶会论文
- 标题：Practical Multi-party Private Set Intersection from Symmetric-Key Techniques
- 收录会议：CCS 2017（安全顶会）
- 论文/课程/项目链接：[https://eprint.iacr.org/2017/799.pdf](https://eprint.iacr.org/2017/799.pdf)
- 推荐理由：

该论文提出了第一个半诚实敌手模型下高效的多方隐私集合求交（Multi-party Private Set Intersection, mPSI）协议。

半诚实敌手模型下，mPSI相比于常见的两方PSI（2-party PSI），其最大的区别在于多方场景存在若干个参与方共谋的情况，如何保证不向共谋方泄漏诚实方持有的集合信息是mPSI面临的最大挑战之一。

本文的主要创新在于，提出了一个高效的mPSI计算范式，这里暂且称为zero-sharing + reconstruction范式。该范式支持在抵抗共谋攻击的前提下，实现mPSI的功能。其主要思想是：在zero-sharing阶段，所有参与方对自己集合中的每个元素分配一个随机数，对于那些交集中的元素，这些随机数异或起来等于0，否则为随机数；在reconstruction阶段，一个Leader用自己集合中的每个元素向其他所有参与方轮询该元素对应的随机数。如果得到的随机数异或起来等于0，那么就证明这是交集中的元素。

在构造zero-sharing和reconstruction阶段时，本文提出了一个新的原语Oblivious Programmable Pseudorandom Function (OPPRF)。该原语类似OPRF，只是Receiver获得的值是由Sender事先进行过program的。该原语可以使用Oblivious Transfer (OT)来高效地构造。因此，尽管为了抵抗共谋攻击，zero-sharing阶段时两两之间都需要执行OPPRF，但整个协议依旧是高效的。