### PR TITLE
【PSI-paper】Efficient Scalable Multi-Party Private Set Intersection(-Variants) from Bicentric Zero-Sharing

### DIFF
--- a/cryptography/psi.md
+++ b/cryptography/psi.md
@@ -138,3 +138,7 @@ Note: one paper may be included in several categories (e.g. a paper may introduc
 - Malicious Secure, Structure-Aware Private Set Intersection
   *Gayathri Garimella, Mike Rosulek, Jaspal Singh*
   CRYPTO 2023, [eprint](https://eprint.iacr.org/2023/1166), GRS23
+
+- Efficient Scalable Multi-Party Private Set Intersection(-Variants) from Bicentric Zero-Sharing
+  *Ying Gao, Yuanchao Luo, Longxin Wang, Xiang Liu, Lin Qi, Wei Wang, Mengmeng Zhou*
+  CCS 2024, [ccs](https://dl.acm.org/doi/10.1145/3658644.3690245), GLWL+24


### PR DESCRIPTION
- 推荐类别：顶会论文
- 标题：Efficient Scalable Multi-Party Private Set Intersection(-Variants) from Bicentric Zero-Sharing
- 收录会议：CCS 2024（安全顶会）
- 论文/课程/项目链接：[https://dl.acm.org/doi/10.1145/3658644.3690245](https://dl.acm.org/doi/10.1145/3658644.3690245)
- 推荐理由：

该论文提出了一个半诚实敌手模型下具有可扩展性的多方隐私集合求交（Multi-party Private Set Intersection, mPSI）协议。其中，可扩展性指当参与方数量极大（如140）时，协议依旧具备相当好的性能。为了获得如此高的性能，本文在安全性上做出了取舍。相比于之前能够抵抗任意敌手合谋的zero-sharing+reconstruction框架，本文要求某两个特定的参与方（即Leader和Pivot）不能合谋。

在这样的安全性假设下，本文的设计思路就和之前的文章大为不同。本文的思路是将mPSI的执行转化为两方PSI协议的执行。这里涉及到两个阶段：一是所有参与方将自己的集合规约到Leader和Pivot手上，这一步我们称为reduction阶段；二是Leader和Pivot之间用规约后的集合执行两方PSI协议。对于第二个阶段，文章直接使用了已有的高效两方PSI协议，这里不再赘述。

对于第一个阶段，由于文章降低了安全性需求，因此得以仅使用对称密码操作来进行构造。具体来说，本文使用了Oblivious Key-Value Store (OKVS)原语来进行构造。该原语分为 $\textsf{Encode}$ 算法和 $\textsf{Decode}$ 算法，两个算法都仅需要对称密码操作，相当高效。所有参与方首先对自己的集合进行 $\textsf{Encode}$ 操作，发送给Leader和Pivot。然后，Leader和Pivot在本地执行 $\textsf{Decode}$ 操作，即可完成第一阶段。

实验表明，文章的方案相当高效，对于140个参与方， $2^{20}$ 大小的集合，LAN网络下的运行时间只需要4.557s。