### PR TITLE
【PSI-paper】Efficient Linear Multiparty PSI and Extensions to Circuit/Quorum PSI

### DIFF
--- a/cryptography/psi.md
+++ b/cryptography/psi.md
@@ -55,10 +55,6 @@ Note: one paper may be included in several categories (e.g. a paper may introduc
   *Nishanth Chandran, Divya Gupta, Akash Shah*
   PETS 2022, [eprint](https://eprint.iacr.org/2021/034), CGS22
 
-- Simple, Fast Malicious Multiparty Private Set Intersection
-  *Ofri Nevo, Ni Trieu, Avishay Yanai*
-  CCS 2021, [eprint](https://eprint.iacr.org/2021/1221), NTY21
-
 - Private Set Operations from Oblivious Switching
   *Gayathri Garimella, Payman Mohassel, Mike Rosulek, Saeed Sadeghian, Jaspal Singh*
   PKC 2021, [eprint](https://eprint.iacr.org/2021/243), GMRS21
@@ -117,6 +113,28 @@ Note: one paper may be included in several categories (e.g. a paper may introduc
   *Peter Rindal, Phillipp Schoppmann*
   EuroCrypt 2021, [eprint](https://eprint.iacr.org/2021/266), RS21
 
+## Multi-party PSI
+
+- Practical Multi-party Private Set Intersection from Symmetric-Key Techniques
+  *Vladimir Kolesnikov, Naor Matania, Benny Pinkas, Mike Rosulek, Ni Trieu*
+  CCS 2017, [eprint](https://eprint.iacr.org/2017/799.pdf), KMPR+17
+  
+- Efficient Linear Multiparty PSI and Extensions to Circuit/Quorum PSI
+  *Nishanth Chandran, Nishka Dasgupta, Divya Gupta, Sai Lakshmi Bhavana Obbattu, Sruthi Sekar, Akash Shah*
+  CCS 2021, [eprint](https://eprint.iacr.org/2021/172.pdf), CDGO+21
+  
+- Simple, Fast Malicious Multiparty Private Set Intersection
+  *Ofri Nevo, Ni Trieu, Avishay Yanai*
+  CCS 2021, [eprint](https://eprint.iacr.org/2021/1221), NTY21
+  
+- O-Ring and K-Star: Efficient Multi-party Private Set Intersection
+  *Mingli Wu, Tsz Hon Yuen, Kwan Yin Chan*
+  USENIX 2024, [usenix](https://www.usenix.org/conference/usenixsecurity24/presentation/wu-mingli), WYC24
+  
+- Efficient Scalable Multi-Party Private Set Intersection(-Variants) from Bicentric Zero-Sharing
+  *Ying Gao, Yuanchao Luo, Longxin Wang, Xiang Liu, Lin Qi, Wei Wang, Mengmeng Zhou*
+  CCS 2024, [ccs](https://dl.acm.org/doi/10.1145/3658644.3690245), GLWL+24
+
 ## Other Variants
 
 - Labeled PSI from Homomorphic Encryption with Reduced Computation and Communication
@@ -139,18 +157,3 @@ Note: one paper may be included in several categories (e.g. a paper may introduc
   *Gayathri Garimella, Mike Rosulek, Jaspal Singh*
   CRYPTO 2023, [eprint](https://eprint.iacr.org/2023/1166), GRS23
 
-- Efficient Scalable Multi-Party Private Set Intersection(-Variants) from Bicentric Zero-Sharing
-  *Ying Gao, Yuanchao Luo, Longxin Wang, Xiang Liu, Lin Qi, Wei Wang, Mengmeng Zhou*
-  CCS 2024, [ccs](https://dl.acm.org/doi/10.1145/3658644.3690245), GLWL+24
-  
-- Practical Multi-party Private Set Intersection from Symmetric-Key Techniques
-  *Vladimir Kolesnikov, Naor Matania, Benny Pinkas, Mike Rosulek, Ni Trieu*
-  CCS 2017, [eprint](https://eprint.iacr.org/2017/799.pdf), KMPR+17
-  
-- Efficient Linear Multiparty PSI and Extensions to Circuit/Quorum PSI
-  *Nishanth Chandran, Nishka Dasgupta, Divya Gupta, Sai Lakshmi Bhavana Obbattu, Sruthi Sekar, Akash Shah*
-  CCS 2021, [eprint](https://eprint.iacr.org/2021/172.pdf), CDGO+21
-  
-- O-Ring and K-Star: Efficient Multi-party Private Set Intersection
-  *Mingli Wu, Tsz Hon Yuen, Kwan Yin Chan*
-  USENIX 2024, [usenix](https://www.usenix.org/conference/usenixsecurity24/presentation/wu-mingli), WYC24

--- a/cryptography/psi.md
+++ b/cryptography/psi.md
@@ -129,7 +129,7 @@ Note: one paper may be included in several categories (e.g. a paper may introduc
   
 - O-Ring and K-Star: Efficient Multi-party Private Set Intersection
   *Mingli Wu, Tsz Hon Yuen, Kwan Yin Chan*
-  USENIX 2024, [usenix](https://www.usenix.org/conference/usenixsecurity24/presentation/wu-mingli), WYC24
+  USENIX Security 2024, [usenix](https://www.usenix.org/conference/usenixsecurity24/presentation/wu-mingli), WYC24
   
 - Efficient Scalable Multi-Party Private Set Intersection(-Variants) from Bicentric Zero-Sharing
   *Ying Gao, Yuanchao Luo, Longxin Wang, Xiang Liu, Lin Qi, Wei Wang, Mengmeng Zhou*

--- a/cryptography/psi.md
+++ b/cryptography/psi.md
@@ -138,3 +138,7 @@ Note: one paper may be included in several categories (e.g. a paper may introduc
 - Malicious Secure, Structure-Aware Private Set Intersection
   *Gayathri Garimella, Mike Rosulek, Jaspal Singh*
   CRYPTO 2023, [eprint](https://eprint.iacr.org/2023/1166), GRS23
+
+- Efficient Linear Multiparty PSI and Extensions to Circuit/Quorum PSI
+  *Nishanth Chandran, Nishka Dasgupta, Divya Gupta, Sai Lakshmi Bhavana Obbattu, Sruthi Sekar, Akash Shah*
+  CCS 2021, [eprint](https://eprint.iacr.org/2021/172.pdf), CDGO+21


### PR DESCRIPTION
- 推荐类别：顶会论文
- 标题：Efficient Linear Multiparty PSI and Extensions to Circuit/Quorum PSI
- 收录会议：CCS 2021（安全顶会）
- 论文/课程/项目链接：[https://eprint.iacr.org/2021/172.pdf](https://eprint.iacr.org/2021/172.pdf)
- 推荐理由：

本文也是针对mPSI问题进行的方案设计。我们说[KMP+17](https://eprint.iacr.org/2017/799.pdf)给出了zero-sharing+reconstruction的计算范式，[GLW+24](https://dl.acm.org/doi/10.1145/3658644.3690245)基于将多方PSI规约到两方PSI的计算范式。本文的设计思路则与上面两个计算范式都不相同。

本文的设计思路是，固定一个参与方为Leader。对于Leader集合中的每一个元素，Leader与每一个其他参与方两两之间执行一个安全两方计算协议。考虑Leader（假设为 $P_1$ ）与 $P_i$ 之间执行的协议，对于 $P_1$ 持有的每一个元素 $x_1^j$，如果它在 $P_i$ 持有的集合 $X_i$ 中，那么两人会获得相同的随机数 $s_{1,i}^j=s_i^j$，否则获得不同的随机数 $s_1^j \neq s_1^j$。之后，所有参与方会参与到一个多方安全算术计算中，他们会协同计算 $v_j = r\cdot (\sum s_{1,i}^j - \sum s_i^j)$，其中 $r$ 是一个随机数。如果 $v_j = 0$，那么该元素是交集中的元素。

本文由于引入了算术计算，因此我们可以利用 $s_{1,i}^j$ 和 $s_i^j$ 来做更多的事情。比如进一步计算交集元素的分享值，这就构造出了Circuit PSI；又比如判断是否有大于 $k$ 个人持有某个元素，这就构造了一种门限PSI，文章中称为Quorum PSI。

但需要提到的是，我们说mPSI中需要解决的挑战是合谋攻击，本文无法抵御任意敌手的合谋攻击。个人认为是由于文章采用的多方安全算术计算仅在honest-majority模型下安全，因此导致了整个方案也仅能在honest-majority模型下安全。